### PR TITLE
Fixed upload url.

### DIFF
--- a/tasks/github_releaser.js
+++ b/tasks/github_releaser.js
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
     };
 
     var makeUploadUrl = function (uploadUrl, filename) {
-        return uploadUrl.replace(/{(\S+)}/gi, '$1=' + filename);
+        return uploadUrl.replace(/{(\S+)}/gi, '?name=' + filename);
     };
 
     var showError = function (err, noExit) {


### PR DESCRIPTION
Behaviour: Asset was not uploaded. Without error or something.
Information / Example:
`upload_url` from response is: `https://uploads.github.com/repos/octocat/Hello-World/releases/1/assets{?name,label}`
Was: `https://uploads.github.com/repos/octocat/Hello-World/releases/1/assets?name,label=release.zip`
Fixed: `https://uploads.github.com/repos/octocat/Hello-World/releases/1/assets?name=release.zip`
where release.zip is the asset to be uploaded.


