### PR TITLE
Use templates to construct valid GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "request": "~2.33.0",
     "underscore": "~1.5.2",
-    "async": "~0.2.10"
+    "async": "~0.2.10",
+    "url-template": "~2.0.6"
   }
 }

--- a/tasks/github_releaser.js
+++ b/tasks/github_releaser.js
@@ -12,7 +12,8 @@ var request = require('request'),
     fs = require('fs'),
     path = require('path'),
     _ = require('underscore'),
-    async = require('async');
+    async = require('async'),
+    template = require('url-template');
 
 module.exports = function(grunt) {
 
@@ -57,8 +58,11 @@ module.exports = function(grunt) {
         });
     };
 
-    var makeUploadUrl = function (uploadUrl, filename) {
-        return uploadUrl.replace(/{(\S+)}/gi, '?name=' + filename);
+      var makeUploadUrl = function (uploadUrl, filename) {
+        var uploadTemplate = template.parse(uploadUrl);
+        return uploadTemplate.expand({
+          name: filename
+        });
     };
 
     var showError = function (err, noExit) {


### PR DESCRIPTION
When creating a release through the [GitHub API](https://developer.github.com/v3/repos/releases/#create-a-release) the `upload_url` to upload
assets is returned in the response. This URL conforms to the [RFC 6570
URI Template specification](http://tools.ietf.org/html/rfc6570) and contains possible query parameters.

Last week our asset uploading was failing out of the blue. No configuration
changes, no version changes. It turns out that on our repositories the `upload_url`
returned by GitHub has changed slightly. If the returned `upload_url`
contains more than one possible query parameter, for example and this is the case for us
`https://uploads.github.com/repos/.../releases/123/assets{?name,label}`
then the mechanism for constructing the final upload URL was failing and
the assets where never uploaded.

To create a valid URL the [url-template](https://www.npmjs.com/package/url-template) package is now used to reliably
set the name query parameter and ignore any other parameters. This will
also works if GitHub adds more optional parameters to the `upload_url`
specification.
